### PR TITLE
Fix: Use working @nanopub/sign@0.1.4 and pre-built nanopub-create

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,54 +185,15 @@ jobs:
       
       - name: Build nanopub-create dependency
         run: |
-          echo "📦 Building nanopub-create library from GitHub..."
-          cd node_modules/@sciencelivehub/nanopub-create
-          
-          # Install dependencies
-          npm install
-          
-          # Create a temporary library-only vite config
-          cat > vite.lib.config.js << 'VITE_EOF'
-          import { defineConfig } from 'vite';
-          import path from 'path';
-          import wasm from 'vite-plugin-wasm';
-          import topLevelAwait from 'vite-plugin-top-level-await';
-          
-          export default defineConfig({
-            plugins: [
-              wasm(),
-              topLevelAwait()
-            ],
-            build: {
-              lib: {
-                entry: path.resolve(__dirname, 'src/index.js'),
-                name: 'NanopubCreator',
-                formats: ['es', 'umd'],
-                fileName: (format) => {
-                  if (format === 'es') return 'nanopub-creator.esm.js';
-                  if (format === 'umd') return 'nanopub-creator.js';
-                }
-              },
-              rollupOptions: {
-                output: {
-                  assetFileNames: (assetInfo) => {
-                    if (assetInfo.name === 'style.css') return 'nanopub-creator.css';
-                    return assetInfo.name;
-                  }
-                }
-              }
-            }
-          });
-          VITE_EOF
-          
-          # Build using the library config
-          npx vite build --config vite.lib.config.js
-          
-          cd ../../..
-          
-          echo "✅ nanopub-create built successfully"
+          echo "📦 Verifying  anopub-create library from GitHub..."
+          if [ ! -f "node_modules/@sciencelivehub/nanopub-create/dist/nanopub-creator.esm.js" ]; then
+            echo "❌ ERROR: nanopub-creator.esm.js not found!"
+            exit 1
+          fi
+    
+          echo "✅ nanopub-create dist/ folder exists"
           ls -lah node_modules/@sciencelivehub/nanopub-create/dist/
-      
+
       - name: Build plugin
         run: npm run build
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,56 +196,17 @@ jobs:
         fi
         
         echo "✅ nanopub-view verification passed!"
-    
+
     - name: Build nanopub-create dependency
-      run: |
-        echo "📦 Building nanopub-create library from GitHub..."
-        cd node_modules/@sciencelivehub/nanopub-create
-        
-        # Install dependencies
-        npm install
-        
-        # Create a temporary library-only vite config
-        cat > vite.lib.config.js << 'VITE_EOF'
-        import { defineConfig } from 'vite';
-        import path from 'path';
-        import wasm from 'vite-plugin-wasm';
-        import topLevelAwait from 'vite-plugin-top-level-await';
-        
-        export default defineConfig({
-          plugins: [
-            wasm(),
-            topLevelAwait()
-          ],
-          build: {
-            lib: {
-              entry: path.resolve(__dirname, 'src/index.js'),
-              name: 'NanopubCreator',
-              formats: ['es', 'umd'],
-              fileName: (format) => {
-                if (format === 'es') return 'nanopub-creator.esm.js';
-                if (format === 'umd') return 'nanopub-creator.js';
-              }
-            },
-            rollupOptions: {
-              output: {
-                assetFileNames: (assetInfo) => {
-                  if (assetInfo.name === 'style.css') return 'nanopub-creator.css';
-                  return assetInfo.name;
-                }
-              }
-            }
-          }
-        });
-        VITE_EOF
-        
-        # Build using the library config
-        npx vite build --config vite.lib.config.js
-        
-        cd ../../..
-        
-        echo "✅ nanopub-create built successfully"
-        ls -lah node_modules/@sciencelivehub/nanopub-create/dist/
+        run: |
+          echo "📦 Verifying  anopub-create library from GitHub..."
+          if [ ! -f "node_modules/@sciencelivehub/nanopub-create/dist/nanopub-creator.esm.js" ]; then
+            echo "❌ ERROR: nanopub-creator.esm.js not found!"
+            exit 1
+          fi
+    
+          echo "✅ nanopub-create dist/ folder exists"
+          ls -lah node_modules/@sciencelivehub/nanopub-create/dist/
     
     - name: Build plugin
       run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Build output
 build/
-dist/
 *.xpi
 
 # Dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
-        "@sciencelivehub/nanopub-create": "github:ScienceLiveHub/nanopub-create",
+        "@nanopub/sign": "^0.1.4",
+        "@sciencelivehub/nanopub-create": "github:ScienceLiveHub/nanopub-create#v1.0.4",
         "@sciencelivehub/nanopub-view": "github:ScienceLiveHub/nanopub-view",
         "zotero-plugin-toolkit": "^2.3.37"
       },
@@ -414,9 +415,9 @@
       }
     },
     "node_modules/@nanopub/sign": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@nanopub/sign/-/sign-0.1.5.tgz",
-      "integrity": "sha512-rQZBrYfjtBmSifM8Ub+PVrD94rTvSY6JzUnNml1P2A4Qq5HHqfrMckgO/4RXbYDY+cFUaJ0al5yDhM0tNvtC8w==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@nanopub/sign/-/sign-0.1.4.tgz",
+      "integrity": "sha512-QoPBC5Fg20GcTPz/Rtlkq3E8DnwpsAIKSLaTpTp/1bTWY8ZlHZh1ik4pQSZZfUwOWiNtZTwdiO2/GtKY0krZkw==",
       "license": "MIT"
     },
     "node_modules/@napi-rs/canvas": {
@@ -605,8 +606,8 @@
       }
     },
     "node_modules/@sciencelivehub/nanopub-create": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/ScienceLiveHub/nanopub-create.git#80f6adf1b9e210bd8bf2d55d284d37324d9067e7",
+      "version": "1.0.1",
+      "resolved": "git+ssh://git@github.com/ScienceLiveHub/nanopub-create.git#781ae4e9c5ae2bc5da8f8174689ac591dcc7be5b",
       "license": "MIT",
       "dependencies": {
         "@nanopub/sign": "^0.1.4"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "zotero-types": "^2.2.1"
   },
   "dependencies": {
-    "@sciencelivehub/nanopub-create": "github:ScienceLiveHub/nanopub-create",
+    "@nanopub/sign": "^0.1.4",
+    "@sciencelivehub/nanopub-create": "github:ScienceLiveHub/nanopub-create#v1.0.4",
     "@sciencelivehub/nanopub-view": "github:ScienceLiveHub/nanopub-view",
     "zotero-plugin-toolkit": "^2.3.37"
   }

--- a/scripts/build-deps.sh
+++ b/scripts/build-deps.sh
@@ -46,18 +46,30 @@ echo "✅ nanopub-view built"
 ls -lah node_modules/@sciencelivehub/nanopub-view/dist/
 
 # Build nanopub-create
-echo "📦 Building nanopub-create..."
+echo "📦 Building nanopub-create with WASM inlining..."
 cd node_modules/@sciencelivehub/nanopub-create
 
 # Install its dependencies
 npm install
 
-# Build it (it already has vite.lib.config.js)
+echo "🔍 Checking for WASM files before build..."
+find node_modules/@nanopub/sign -name "*.wasm" 2>/dev/null || echo "No WASM files found"
+
+# Build it (now with WASM inlining)
+echo "🔨 Building with vite.lib.config.js..."
 npx vite build --config vite.lib.config.js
 
-cd ../../..
-
 echo "✅ nanopub-create built"
-ls -lah node_modules/@sciencelivehub/nanopub-create/dist/
+echo "📊 Build output:"
+ls -lah dist/
+
+echo "📏 Bundle sizes:"
+du -h dist/nanopub-creator.esm.js
+du -h dist/nanopub-creator.js
+
+echo "🔍 Checking for WASM files in output (should be none)..."
+find dist/ -name "*.wasm" 2>/dev/null || echo "✅ No separate WASM files (good - it's inlined!)"
+
+cd ../../..
 
 echo "✅ All dependencies built successfully"


### PR DESCRIPTION
- Update to @nanopub/sign@0.1.4 (0.1.5 has broken trusty hash generation)
- Use pre-built dist/ from nanopub-create (now committed to GitHub)
- Remove workflow build steps for nanopub-create
- Simplifies CI/CD and ensures consistent builds